### PR TITLE
docs: use static View.availableEnvironments

### DIFF
--- a/demo-snippets/guides/views/environments.ts
+++ b/demo-snippets/guides/views/environments.ts
@@ -4,7 +4,7 @@ const { mesh } = createSphereObject();
 
 export async function main(view: View) {
     const envIndexUrl = new URL("https://api.novorender.com/assets/env/index.json");
-    const envs = await view.availableEnvironments(envIndexUrl);
+    const envs = await View.availableEnvironments(envIndexUrl);
     const { url } = envs[2]; // just pick one
     view.modifyRenderState({
         background: { url, blur: 0 }, // may take a while to download

--- a/docs/guides/views.mdx
+++ b/docs/guides/views.mdx
@@ -193,7 +193,7 @@ The view contains a function <CodeLink type="class" name="View.availableEnvironm
 We've already included some environments on our `api.novorender.com` server, so that's were we'll point it to.
 
 ```typescript
-const envs = await view.availableEnvironments("https://api.novorender.com/assets/env/index.json");
+const envs = await View.availableEnvironments("https://api.novorender.com/assets/env/index.json");
 const {url} = envs[0];
 view.modifyRenderState({ background: { url } });
 ```


### PR DESCRIPTION
As per documentation itself ([ref](https://docs.novorender.com/docs/web_api/Classes/class.View#deprecated)) `availableEnvironments` is `static` now.